### PR TITLE
修复Tabs children变化value不变时，激活指示器位置错误

### DIFF
--- a/packages/bui-core/src/Tabs/Tabs.tsx
+++ b/packages/bui-core/src/Tabs/Tabs.tsx
@@ -110,7 +110,7 @@ const Tabs = React.forwardRef<HTMLDivElement, TabsProps>((props, ref) => {
 
   useDidMountEffect(() => {
     animate({ transitionInUse: true });
-  }, [active, tabs]);
+  }, [active, tabs, children]);
 
   const safeValue = () => {
     let defaultIndex = value;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!--
首先，感谢你的贡献！
新特性请提交至 main 分支，在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

<!-- Tips: "[ ]" 更改为 "[x]" 可选中复选框 -->

**这个 PR 做了什么?**
修复Tabs children变化value不变时，激活指示器位置错误

**这个变动的性质是？**

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 工作流程

**这个变动涉及以下渠道:**

- [x] 所有渠道
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 抖音小程序
- [ ] Web 平台（H5）

**附加信息（可选）**
完成issue：Closes #20  
