### PR TITLE
fix: 通过高阶组件包裹的Tab无法使用type判断children类型

### DIFF
--- a/packages/bui-core/src/Tabs/Tabs.tsx
+++ b/packages/bui-core/src/Tabs/Tabs.tsx
@@ -118,10 +118,7 @@ const Tabs = React.forwardRef<HTMLDivElement, TabsProps>((props, ref) => {
     const hasSameChild =
       !!childs.length &&
       childs.some(
-        (child) =>
-          React.isValidElement(child) &&
-          child.type === Tab &&
-          child?.props?.index === value,
+        (child) => React.isValidElement(child) && child?.props?.index === value,
       );
     if (!!tabs.length && !tabs.some((item) => item.index === value)) {
       defaultIndex = tabs[0]?.index;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!--
首先，感谢你的贡献！
新特性请提交至 main 分支，在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

<!-- Tips: "[ ]" 更改为 "[x]" 可选中复选框 -->

**这个 PR 做了什么?**
修复通过高阶组件包裹的Tab无法使用type判断children类型，如DynamicDiv

**这个变动的性质是？**

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 工作流程

**这个变动涉及以下渠道:**

- [x] 所有渠道
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 抖音小程序
- [ ] Web 平台（H5）

**附加信息（可选）**
在此添加任何其他相关信息，比如截图或设计图。
