### PR TITLE
feat: CitySelector支持定制侧边栏标题、选中城市激活类名

### DIFF
--- a/packages/bui-core/src/CitySelector/CitySelector.types.ts
+++ b/packages/bui-core/src/CitySelector/CitySelector.types.ts
@@ -32,6 +32,12 @@ export type CitySelectorProps<
       hotCities?: cityType[];
       /** 热门城市栏的title */
       hotCitiesGroupName?: string;
+      /** 侧边栏的当前城市title */
+      sideBarSelectedCityGroupName?: string;
+      /** 侧边栏的定位城市title */
+      sideBarCurrentCityGroupName?: string;
+      /** 侧边栏的热门城市title */
+      sideBarHotCitiesGroupName?: string;
       /** 城市列表 */
       cities: allCityItemType[];
       /** 禁用展示索引 默认false 即展示索引 */

--- a/packages/bui-core/src/CitySelector/CitySelectorCore.tsx
+++ b/packages/bui-core/src/CitySelector/CitySelectorCore.tsx
@@ -32,6 +32,9 @@ const CitySelector = React.forwardRef<HTMLDivElement, CitySelectorCoreProps>(
       currentCityGroupName = currentCityGroupLocaleName,
       hotCities,
       hotCitiesGroupName = hotCitiesGroupLocaleName,
+      sideBarSelectedCityGroupName = current,
+      sideBarCurrentCityGroupName = located,
+      sideBarHotCitiesGroupName = hot,
       cities,
       disableIndex,
       touchHandler,
@@ -42,16 +45,16 @@ const CitySelector = React.forwardRef<HTMLDivElement, CitySelectorCoreProps>(
     } = props;
 
     const GPS_TYPE = {
-      title: located,
+      title: sideBarCurrentCityGroupName,
       code: 'GPS',
     };
     const CURRENT_TYPE = {
-      title: current,
+      title: sideBarSelectedCityGroupName,
       code: 'CRRT',
     };
 
     const HOT_CITY_TYPE = {
-      title: hot,
+      title: sideBarHotCitiesGroupName,
       code: 'HOT',
     };
 
@@ -135,13 +138,28 @@ const CitySelector = React.forwardRef<HTMLDivElement, CitySelectorCoreProps>(
     };
 
     const renderCity = (citys, title, titleCode?) => {
+      const parsedCode = titleCode?.toLowerCase();
       return (
         <div>
           {renderTitle(title, titleCode)}
-          <div className="select-city-buttons">
+          <div
+            className={clsx(
+              'select-city-buttons',
+              `select-city-buttons-${parsedCode}`,
+            )}
+          >
             {citys.map((city, index) => {
               return (
-                <Selector key={index} city={city} onSelect={selectHandler} />
+                <Selector
+                  className={
+                    city.code === selectedCity.code
+                      ? `bui-select-city-item-active`
+                      : ''
+                  }
+                  key={index}
+                  city={city}
+                  onSelect={selectHandler}
+                />
               );
             })}
           </div>

--- a/packages/bui-core/src/CitySelector/Selector/index.tsx
+++ b/packages/bui-core/src/CitySelector/Selector/index.tsx
@@ -1,17 +1,19 @@
 import React from 'react';
+import clsx from 'clsx';
 import { cityType } from '../CitySelector.types';
 import './index.less';
 
 type propsType = {
+  className: string;
   city: cityType;
   onSelect: (e: React.SyntheticEvent, city: cityType) => void;
 };
 
 const Selector = (props: propsType) => {
-  const { city, onSelect } = props;
+  const { className, city, onSelect } = props;
   return (
     <span
-      className="bui-city-selector-item"
+      className={clsx(className, 'bui-city-selector-item')}
       onClick={(e) => {
         onSelect?.(e, city);
       }}

--- a/packages/bui-core/src/CitySelector/__tests__/__snapshots__/CitySelector.snapshot.test.tsx.snap
+++ b/packages/bui-core/src/CitySelector/__tests__/__snapshots__/CitySelector.snapshot.test.tsx.snap
@@ -26,10 +26,10 @@ exports[`CitySelector snapshot CitySelector demo snapshot 0 1`] = `
           当前城市
         </div>
         <div
-          className="select-city-buttons"
+          className="select-city-buttons select-city-buttons-crrt"
         >
           <span
-            className="bui-city-selector-item"
+            className="bui-select-city-item-active bui-city-selector-item"
             onClick={[Function]}
           >
             北京
@@ -44,7 +44,7 @@ exports[`CitySelector snapshot CitySelector demo snapshot 0 1`] = `
           定位城市
         </div>
         <div
-          className="select-city-buttons"
+          className="select-city-buttons select-city-buttons-gps"
         >
           <span
             className="bui-city-selector-item"
@@ -62,10 +62,10 @@ exports[`CitySelector snapshot CitySelector demo snapshot 0 1`] = `
           热门城市
         </div>
         <div
-          className="select-city-buttons"
+          className="select-city-buttons select-city-buttons-hot"
         >
           <span
-            className="bui-city-selector-item"
+            className="bui-select-city-item-active bui-city-selector-item"
             onClick={[Function]}
           >
             北京
@@ -226,10 +226,10 @@ exports[`CitySelector snapshot CitySelector demo snapshot 0 2`] = `
           当前城市
         </div>
         <div
-          className="select-city-buttons"
+          className="select-city-buttons select-city-buttons-crrt"
         >
           <span
-            className="bui-city-selector-item"
+            className="bui-select-city-item-active bui-city-selector-item"
             onClick={[Function]}
           >
             北京
@@ -244,7 +244,7 @@ exports[`CitySelector snapshot CitySelector demo snapshot 0 2`] = `
           定位城市
         </div>
         <div
-          className="select-city-buttons"
+          className="select-city-buttons select-city-buttons-gps"
         >
           <span
             className="bui-city-selector-item"
@@ -262,10 +262,10 @@ exports[`CitySelector snapshot CitySelector demo snapshot 0 2`] = `
           热门城市
         </div>
         <div
-          className="select-city-buttons"
+          className="select-city-buttons select-city-buttons-hot"
         >
           <span
-            className="bui-city-selector-item"
+            className="bui-select-city-item-active bui-city-selector-item"
             onClick={[Function]}
           >
             北京
@@ -415,10 +415,10 @@ exports[`CitySelector snapshot CitySelector demo snapshot 0 3`] = `
           当前城市
         </div>
         <div
-          className="select-city-buttons"
+          className="select-city-buttons select-city-buttons-crrt"
         >
           <span
-            className="bui-city-selector-item"
+            className="bui-select-city-item-active bui-city-selector-item"
             onClick={[Function]}
           >
             北京
@@ -433,7 +433,7 @@ exports[`CitySelector snapshot CitySelector demo snapshot 0 3`] = `
           定位城市
         </div>
         <div
-          className="select-city-buttons"
+          className="select-city-buttons select-city-buttons-gps"
         >
           <span
             className="bui-city-selector-item"
@@ -451,10 +451,10 @@ exports[`CitySelector snapshot CitySelector demo snapshot 0 3`] = `
           热门城市
         </div>
         <div
-          className="select-city-buttons"
+          className="select-city-buttons select-city-buttons-hot"
         >
           <span
-            className="bui-city-selector-item"
+            className="bui-select-city-item-active bui-city-selector-item"
             onClick={[Function]}
           >
             北京


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!--
首先，感谢你的贡献！
新特性请提交至 main 分支，在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

<!-- Tips: "[ ]" 更改为 "[x]" 可选中复选框 -->

**这个 PR 做了什么?**
CitySelector支持定制侧边栏标题、选中城市增加激活类名

**这个变动的性质是？**
- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 工作流程

**这个变动涉及以下渠道:**

- [x] 所有渠道
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 抖音小程序
- [ ] Web 平台（H5）

**附加信息（可选）**
在此添加任何其他相关信息，比如截图或设计图。
